### PR TITLE
#8: cmake: fix vt-trace mode linking target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,5 +42,5 @@ add_executable(
 
 target_link_libraries(${TRACE_ONLY_SAMPLE} PUBLIC detector)
 target_link_libraries(${TRACE_ONLY_SAMPLE} PUBLIC checkpoint)
-target_link_libraries(${TRACE_ONLY_SAMPLE} PUBLIC vt::vt-trace)
+target_link_libraries(${TRACE_ONLY_SAMPLE} PUBLIC vt-trace)
 ############################################################


### PR DESCRIPTION
Fixes #8